### PR TITLE
Create処理のDBテストの実装

### DIFF
--- a/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
+++ b/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
@@ -93,6 +93,15 @@ class UserMapperTest {
     @Test
     @DataSet(value = "datasets/users.yml")
     @Transactional
+    void 存在しないメールアドレスを指定したときに取得されるユーザーが空であること() {
+        User user = new User(null, "ジョン", "john", LocalDate.of(1996, 01, 23), "john@mkdk.com");
+        Optional<User> users = userMapper.findUser(user.getEmail());
+        assertThat(users).isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
     void 新たにレコードが登録できること() {
         User user = new User(null, "加藤花子", "kato hanako", LocalDate.of(1999, 02, 22), "kato@mkdk.com");
         userMapper.createUser(user);

--- a/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
+++ b/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
@@ -82,10 +82,9 @@ class UserMapperTest {
     @Test
     @DataSet(value = "datasets/users.yml")
     @Transactional
-    void 存在するメールアドレスを取得したときにそのユーザーのレコードが取得できること() {
-        User user = new User(null, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com");
-        Optional<User> users = userMapper.findUser(user.getEmail());
-        assertThat(users).contains(
+    void 存在するメールアドレスを指定したときにそのユーザーのレコードが取得できること() {
+        Optional<User> user = userMapper.findUser("yamada@mkdk.com");
+        assertThat(user).contains(
                 new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com")
         );
     }
@@ -94,9 +93,8 @@ class UserMapperTest {
     @DataSet(value = "datasets/users.yml")
     @Transactional
     void 存在しないメールアドレスを指定したときに取得されるユーザーが空であること() {
-        User user = new User(null, "ジョン", "john", LocalDate.of(1996, 01, 23), "john@mkdk.com");
-        Optional<User> users = userMapper.findUser(user.getEmail());
-        assertThat(users).isEmpty();
+        Optional<User> user = userMapper.findUser("john@mkdk.com");
+        assertThat(user).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
+++ b/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
@@ -82,7 +82,7 @@ class UserMapperTest {
     @Test
     @DataSet(value = "datasets/users.yml")
     @Transactional
-    void 存在するメールアドレスを指定したときに紐づいたユーザーが取得できること() {
+    void 存在するメールアドレスを取得したときにそのユーザーのレコードが取得できること() {
         User user = new User(null, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com");
         Optional<User> users = userMapper.findUser(user.getEmail());
         assertThat(users).contains(

--- a/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
+++ b/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
@@ -77,4 +77,34 @@ class UserMapperTest {
         assertThat(users).isEmpty();
     }
 
+    // POST
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 存在するメールアドレスを指定したときに紐づいたユーザーが取得できること() {
+        User user = new User(null, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com");
+        Optional<User> users = userMapper.findUser(user.getEmail());
+        assertThat(users).contains(
+                new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com")
+        );
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 新たにレコードが登録できること() {
+        User user = new User(null, "加藤花子", "kato hanako", LocalDate.of(1999, 02, 22), "kato@mkdk.com");
+        userMapper.createUser(user);
+        List<User> users = userMapper.findAll();
+        assertThat(users).hasSize(5)
+                .contains(
+                        new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"),
+                        new User(2, "山田花子", "yamada hanako", LocalDate.of(2000, 11, 23), "hanako@mkdk.com"),
+                        new User(3, "小山田祐介", "oyamada yusuke", LocalDate.of(2005, 07, 16), "oyamada@mkdk.com"),
+                        new User(4, "山田次郎", "YAMADA JIRO", LocalDate.of(1995, 12, 30), "jiro@mkdk.com"),
+                        user
+                );
+    }
+
 }

--- a/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
+++ b/src/test/java/com/mkdk72ki/asgmt10/mapper/UserMapperTest.java
@@ -23,6 +23,8 @@ class UserMapperTest {
     @Autowired
     UserMapper userMapper;
 
+    // GET
+
     @Test
     @DataSet(value = "datasets/users.yml")
     @Transactional
@@ -77,8 +79,6 @@ class UserMapperTest {
         assertThat(users).isEmpty();
     }
 
-    // POST
-
     @Test
     @DataSet(value = "datasets/users.yml")
     @Transactional
@@ -96,6 +96,8 @@ class UserMapperTest {
         Optional<User> user = userMapper.findUser("john@mkdk.com");
         assertThat(user).isEmpty();
     }
+
+    // POST
 
     @Test
     @DataSet(value = "datasets/users.yml")


### PR DESCRIPTION
# 概要
Create処理について、DBテストを実装しました。  


## 内容
**2つ**のメソッドについて**3つ**のテストコードを作成しました。  

いずれも成功を確認しています。  

https://github.com/mkdk72ki/assignment10/blob/e0ed059886a6fd158d02756d76b8a782be357c80/src/main/java/com/mkdk72ki/asgmt10/mapper/UserMapper.java#L28-L33  

### findUser()メソッド  

- 存在するメールアドレスを取得したときにレコードが取得できること  
- 存在しないメールアドレスを指定したときに取得されるユーザーが空であること  

### createUser()メソッド
  
- 新たにレコードが登録できること