### PR TITLE
Update処理とDelete処理のService単体テストを実装

### DIFF
--- a/src/main/java/com/mkdk72ki/asgmt10/service/UserService.java
+++ b/src/main/java/com/mkdk72ki/asgmt10/service/UserService.java
@@ -47,12 +47,11 @@ public class UserService {
     }
 
     // PATCH
-    public User updateUser(int id, String name, String ruby, LocalDate birthday, String email) {
+    public void updateUser(int id, String name, String ruby, LocalDate birthday, String email) {
         User user = this.userMapper.findById(id)
                 .orElseThrow(() -> new UserNotFoundException("user not found"));
         user.update(name, ruby, birthday, email);
         this.userMapper.updateUser(user);
-        return user;
     }
 
     // DELETE

--- a/src/main/java/com/mkdk72ki/asgmt10/service/UserService.java
+++ b/src/main/java/com/mkdk72ki/asgmt10/service/UserService.java
@@ -47,11 +47,12 @@ public class UserService {
     }
 
     // PATCH
-    public void updateUser(int id, String name, String ruby, LocalDate birthday, String email) {
+    public User updateUser(int id, String name, String ruby, LocalDate birthday, String email) {
         User user = this.userMapper.findById(id)
                 .orElseThrow(() -> new UserNotFoundException("user not found"));
         user.update(name, ruby, birthday, email);
         this.userMapper.updateUser(user);
+        return user;
     }
 
     // DELETE

--- a/src/test/java/com/mkdk72ki/asgmt10/service/UserServiceTest.java
+++ b/src/test/java/com/mkdk72ki/asgmt10/service/UserServiceTest.java
@@ -106,4 +106,79 @@ class UserServiceTest {
         });
     }
 
+    // PATCH
+
+    @Test
+    public void 正常にユーザーの情報が更新できること() throws Exception {
+        doReturn(Optional.of(new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"))).when(userMapper).findById(1);
+        User user = new User(1, "加藤花子", "kato hanako", LocalDate.of(2000, 11, 23), "kato@mkdk.com");
+        User actual = userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
+        assertThat(actual).isEqualTo(user);
+        verify(userMapper, times(1)).findById(1);
+        verify(userMapper, times(1)).updateUser(user);
+    }
+
+    @Test
+    public void 正常にユーザーの名前とルビのみが更新できること() throws Exception {
+        doReturn(Optional.of(new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"))).when(userMapper).findById(1);
+        User user = new User(1, "加藤花子", "kato hanako", null, null);
+        User actual = userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
+        User updatedUser = new User(1, "加藤花子", "kato hanako", LocalDate.of(1990, 03, 04), "yamada@mkdk.com");
+        assertThat(actual).isEqualTo(updatedUser);
+        verify(userMapper, times(1)).findById(1);
+        verify(userMapper, times(1)).updateUser(updatedUser);
+    }
+
+    @Test
+    public void 正常にユーザーの誕生日のみが更新できること() throws Exception {
+        doReturn(Optional.of(new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"))).when(userMapper).findById(1);
+        User user = new User(1, null, null, LocalDate.of(2000, 11, 23), null);
+        User actual = userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
+        User updatedUser = new User(1, "山田太郎", "yamada taro", LocalDate.of(2000, 11, 23), "yamada@mkdk.com");
+        assertThat(actual).isEqualTo(updatedUser);
+        verify(userMapper, times(1)).findById(1);
+        verify(userMapper, times(1)).updateUser(updatedUser);
+    }
+
+    @Test
+    public void 正常にユーザーのメールアドレスのみが更新できること() throws Exception {
+        doReturn(Optional.of(new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"))).when(userMapper).findById(1);
+        User user = new User(1, null, null, null, "taro@mkdk.com");
+        User actual = userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
+        User updatedUser = new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "taro@mkdk.com");
+        assertThat(actual).isEqualTo(updatedUser);
+        verify(userMapper, times(1)).findById(1);
+        verify(userMapper, times(1)).updateUser(updatedUser);
+    }
+
+    @Test
+    public void 更新時に存在しないユーザーを指定したときに適切な例外が返されること() throws Exception {
+        doReturn(Optional.empty()).when(userMapper).findById(99);
+        assertThrows(UserNotFoundException.class, () -> {
+            userService.updateUser(99, "ジョン", "john", LocalDate.of(1999, 01, 23), "john@mkdk.com");
+        });
+        verify(userMapper, times(1)).findById(99);
+        verify(userMapper, times(0)).updateUser(new User(99, "ジョン", "john", LocalDate.of(1999, 01, 23), "john@mkdk.com"));
+    }
+
+    // DELETE
+
+    @Test
+    public void 正常にユーザーが削除できること() throws Exception {
+        doReturn(Optional.of(new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"))).when(userMapper).findById(1);
+        userService.deleteUser(1);
+        verify(userMapper, times(1)).findById(1);
+        verify(userMapper, times(1)).deleteUser(1);
+    }
+
+    @Test
+    public void 削除時に存在しないユーザーを指定したときに適切な例外が返されること() throws Exception {
+        doReturn(Optional.empty()).when(userMapper).findById(99);
+        assertThrows(UserNotFoundException.class, () -> {
+            userService.deleteUser(99);
+        });
+        verify(userMapper, times(1)).findById(99);
+        verify(userMapper, times(0)).deleteUser(99);
+    }
+
 }

--- a/src/test/java/com/mkdk72ki/asgmt10/service/UserServiceTest.java
+++ b/src/test/java/com/mkdk72ki/asgmt10/service/UserServiceTest.java
@@ -112,8 +112,7 @@ class UserServiceTest {
     public void 正常にユーザーの情報が更新できること() throws Exception {
         doReturn(Optional.of(new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"))).when(userMapper).findById(1);
         User user = new User(1, "加藤花子", "kato hanako", LocalDate.of(2000, 11, 23), "kato@mkdk.com");
-        User actual = userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
-        assertThat(actual).isEqualTo(user);
+        userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
         verify(userMapper, times(1)).findById(1);
         verify(userMapper, times(1)).updateUser(user);
     }
@@ -122,9 +121,8 @@ class UserServiceTest {
     public void 正常にユーザーの名前とルビのみが更新できること() throws Exception {
         doReturn(Optional.of(new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"))).when(userMapper).findById(1);
         User user = new User(1, "加藤花子", "kato hanako", null, null);
-        User actual = userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
+        userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
         User updatedUser = new User(1, "加藤花子", "kato hanako", LocalDate.of(1990, 03, 04), "yamada@mkdk.com");
-        assertThat(actual).isEqualTo(updatedUser);
         verify(userMapper, times(1)).findById(1);
         verify(userMapper, times(1)).updateUser(updatedUser);
     }
@@ -133,9 +131,8 @@ class UserServiceTest {
     public void 正常にユーザーの誕生日のみが更新できること() throws Exception {
         doReturn(Optional.of(new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"))).when(userMapper).findById(1);
         User user = new User(1, null, null, LocalDate.of(2000, 11, 23), null);
-        User actual = userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
+        userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
         User updatedUser = new User(1, "山田太郎", "yamada taro", LocalDate.of(2000, 11, 23), "yamada@mkdk.com");
-        assertThat(actual).isEqualTo(updatedUser);
         verify(userMapper, times(1)).findById(1);
         verify(userMapper, times(1)).updateUser(updatedUser);
     }
@@ -144,9 +141,8 @@ class UserServiceTest {
     public void 正常にユーザーのメールアドレスのみが更新できること() throws Exception {
         doReturn(Optional.of(new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "yamada@mkdk.com"))).when(userMapper).findById(1);
         User user = new User(1, null, null, null, "taro@mkdk.com");
-        User actual = userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
+        userService.updateUser(user.getId(), user.getName(), user.getRuby(), user.getBirthday(), user.getEmail());
         User updatedUser = new User(1, "山田太郎", "yamada taro", LocalDate.of(1990, 03, 04), "taro@mkdk.com");
-        assertThat(actual).isEqualTo(updatedUser);
         verify(userMapper, times(1)).findById(1);
         verify(userMapper, times(1)).updateUser(updatedUser);
     }


### PR DESCRIPTION
# 概要
Update処理とDelete処理について、Serviceクラスの単体テストを実装しました。  
また、`updateUser()`の戻り値を`void`から`User`に変更しました。

## 内容
  
### Update処理  
`updateUser()`について**5つ**のテストコードを作成しました。  

https://github.com/mkdk72ki/assignment10/blob/e33a8583fc74a5ec3b544656be79395de8e05d1a/src/main/java/com/mkdk72ki/asgmt10/service/UserService.java#L50-L56  

- 正常に更新ができること
- 名前とルビのみで更新ができること
- 誕生日のみで更新ができること
- メールアドレスのみで更新ができること
- 存在しないユーザーを指定したときに適切な例外が返されること  

### Delete処理  
`deleteUser()`について**2つ**のテストコードを作成しました。  

https://github.com/mkdk72ki/assignment10/blob/e33a8583fc74a5ec3b544656be79395de8e05d1a/src/main/java/com/mkdk72ki/asgmt10/service/UserService.java#L59-L63  
  
- 正常に削除ができること
- 存在しないユーザーを指定したときに適切な例外が返されること